### PR TITLE
feat(deployment): add GitHub Pages deployment support with mock API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,11 @@ VITE_COINGECKO_API_KEY=your-coingecko-api-key
 # Required for connecting to Binance Testnet for sandbox trading
 VITE_BINANCE_TESTNET_API_KEY=your-binance-testnet-api-key
 VITE_BINANCE_TESTNET_API_SECRET=your-binance-testnet-api-secret
+
+# --- GitHub Pages Configuration ---
+# Uncomment the following line to use mock API for local testing
+# VITE_USE_MOCK_API=true
+
+# Base path for GitHub Pages deployment
+# Uncomment and set to your repository name for GitHub Pages deployment
+# VITE_BASE_PATH=/omnitrade-terminal

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  # Allow manual triggering
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: 'npm'
+          
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build with Vite
+        run: npm run build
+        env:
+          # Set base path for GitHub Pages
+          VITE_BASE_PATH: '/omnitrade-terminal'
+          
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/GITHUB_PAGES.md
+++ b/GITHUB_PAGES.md
@@ -1,0 +1,42 @@
+# OmniTrade Terminal - GitHub Pages Demo
+
+This is a static demo version of the OmniTrade Terminal deployed on GitHub Pages. This version demonstrates the UI and functionality using mock data, without requiring a backend server.
+
+## Features Available in This Demo
+
+- Interactive trading terminal UI
+- Mock market data visualization
+- Draggable and resizable panels
+- TabTrader-inspired layout
+- Theme switching
+
+## Limitations of This Demo
+
+Since this is a static GitHub Pages deployment, it has the following limitations:
+
+- Uses mock data instead of real market data
+- No actual trading functionality (simulated only)
+- No authentication with real credentials
+- No persistence between sessions (except for browser localStorage)
+
+## Full Version
+
+For the full version with all features and real-time data, please:
+
+1. Clone the repository: `git clone https://github.com/ArtCenter1/omnitrade-terminal.git`
+2. Install dependencies: `npm install` or `bun install`
+3. Run the development server: `npm run dev` or `bun run dev`
+
+## Development
+
+This GitHub Pages demo is automatically built and deployed from the `main` branch using GitHub Actions. The workflow file is located at `.github/workflows/gh-pages.yml`.
+
+To update this demo:
+
+1. Make changes to the codebase
+2. Commit and push to the `main` branch
+3. GitHub Actions will automatically build and deploy the updated version
+
+## Contact
+
+For questions or support, please open an issue on the [GitHub repository](https://github.com/ArtCenter1/omnitrade-terminal/issues).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider as ShadcnThemeProvider } from '@/components/ThemeProvider
 import '@/styles/themes.css';
 import '@/styles/components.css';
 import { Toaster } from '@/components/ui/sonner';
+import GitHubPagesBanner from '@/components/ui/github-pages-banner';
 // Debug panel imports removed
 // Debug panel removed
 import UserRoleManagement from './pages/admin/UserRoleManagement';
@@ -106,6 +107,7 @@ function App() {
     >
       <ConnectionStatusProvider>
         <Toaster />
+        <GitHubPagesBanner />
         <ScrollToTop />
         <Routes>
           {/* Public routes */}

--- a/src/components/ui/github-pages-banner.tsx
+++ b/src/components/ui/github-pages-banner.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+/**
+ * A banner component that displays a notice when the app is running on GitHub Pages
+ */
+const GitHubPagesBanner: React.FC = () => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  // Only show the banner on GitHub Pages
+  const isGitHubPages = window.location.hostname.includes('github.io') || 
+                        import.meta.env.VITE_USE_MOCK_API === 'true';
+
+  if (!isGitHubPages || !isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 bg-yellow-500 text-black p-2 text-center text-sm">
+      <div className="flex items-center justify-center gap-2">
+        <span>
+          ⚠️ This is a <strong>demo version</strong> running on GitHub Pages with mock data. No real trading is possible.
+        </span>
+        <button 
+          onClick={() => setIsVisible(false)}
+          className="bg-black text-white px-2 py-0.5 rounded text-xs"
+          aria-label="Close banner"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default GitHubPagesBanner;

--- a/src/contexts/GitHubPagesAuthContext.tsx
+++ b/src/contexts/GitHubPagesAuthContext.tsx
@@ -1,0 +1,183 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { mockUser } from '../lib/mock-api';
+
+// Define the auth context type
+interface AuthContextType {
+  user: any | null;
+  loading: boolean;
+  error: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, username: string) => Promise<void>;
+  logout: () => Promise<void>;
+  resetPassword: (email: string) => Promise<void>;
+  updateProfile: (data: any) => Promise<void>;
+}
+
+// Create the context with a default value
+const GitHubPagesAuthContext = createContext<AuthContextType>({
+  user: null,
+  loading: true,
+  error: null,
+  login: async () => {},
+  register: async () => {},
+  logout: async () => {},
+  resetPassword: async () => {},
+  updateProfile: async () => {},
+});
+
+// Custom hook to use the auth context
+export const useGitHubPagesAuth = () => useContext(GitHubPagesAuthContext);
+
+// Provider component
+export const GitHubPagesAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Check for saved user in localStorage on initial load
+  useEffect(() => {
+    const savedUser = localStorage.getItem('github-pages-demo-user');
+    if (savedUser) {
+      setUser(JSON.parse(savedUser));
+    } else {
+      // Auto-login with demo user for GitHub Pages
+      setUser(mockUser);
+      localStorage.setItem('github-pages-demo-user', JSON.stringify(mockUser));
+    }
+    setLoading(false);
+  }, []);
+
+  // Mock login function
+  const login = async (email: string, password: string) => {
+    setLoading(true);
+    try {
+      // Simulate API call delay
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      // Always succeed with mock user
+      setUser(mockUser);
+      localStorage.setItem('github-pages-demo-user', JSON.stringify(mockUser));
+      setError(null);
+    } catch (err) {
+      setError('Login failed');
+      console.error('Login error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Mock register function
+  const register = async (email: string, password: string, username: string) => {
+    setLoading(true);
+    try {
+      // Simulate API call delay
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      // Create a custom user based on input but with mock data structure
+      const newUser = {
+        ...mockUser,
+        email,
+        username,
+      };
+      
+      setUser(newUser);
+      localStorage.setItem('github-pages-demo-user', JSON.stringify(newUser));
+      setError(null);
+    } catch (err) {
+      setError('Registration failed');
+      console.error('Registration error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Mock logout function
+  const logout = async () => {
+    setLoading(true);
+    try {
+      // Simulate API call delay
+      await new Promise(resolve => setTimeout(resolve, 500));
+      
+      setUser(null);
+      localStorage.removeItem('github-pages-demo-user');
+      setError(null);
+    } catch (err) {
+      setError('Logout failed');
+      console.error('Logout error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Mock reset password function
+  const resetPassword = async (email: string) => {
+    setLoading(true);
+    try {
+      // Simulate API call delay
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      // Always succeed
+      setError(null);
+      // Show success message through alert for demo
+      alert(`Password reset email would be sent to ${email} in a real app`);
+    } catch (err) {
+      setError('Password reset failed');
+      console.error('Password reset error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Mock update profile function
+  const updateProfile = async (data: any) => {
+    setLoading(true);
+    try {
+      // Simulate API call delay
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      // Update the user with new data
+      const updatedUser = { ...user, ...data };
+      setUser(updatedUser);
+      localStorage.setItem('github-pages-demo-user', JSON.stringify(updatedUser));
+      setError(null);
+    } catch (err) {
+      setError('Profile update failed');
+      console.error('Profile update error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Create the context value object
+  const contextValue: AuthContextType = {
+    user,
+    loading,
+    error,
+    login,
+    register,
+    logout,
+    resetPassword,
+    updateProfile,
+  };
+
+  return (
+    <GitHubPagesAuthContext.Provider value={contextValue}>
+      {children}
+    </GitHubPagesAuthContext.Provider>
+  );
+};
+
+// Export a wrapper component that conditionally uses this provider for GitHub Pages
+export const ConditionalAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  // Check if we're on GitHub Pages
+  const isGitHubPages = window.location.hostname.includes('github.io') || 
+                        import.meta.env.VITE_USE_MOCK_API === 'true';
+  
+  // If on GitHub Pages, use the GitHub Pages auth provider
+  if (isGitHubPages) {
+    return <GitHubPagesAuthProvider>{children}</GitHubPagesAuthProvider>;
+  }
+  
+  // Otherwise, just render children (the real AuthProvider will be used in main.tsx)
+  return <>{children}</>;
+};

--- a/src/lib/api/api-factory.ts
+++ b/src/lib/api/api-factory.ts
@@ -1,0 +1,37 @@
+/**
+ * API Factory
+ * 
+ * This module determines whether to use the real API client or the mock API client
+ * based on the environment. For GitHub Pages deployments, it will always use the mock API.
+ */
+
+import mockApiClient from '../mock-api';
+
+// Check if we're running on GitHub Pages
+const isGitHubPages = () => {
+  // Check if the base path matches GitHub Pages pattern or if we're in a specific environment
+  return window.location.hostname.includes('github.io') || 
+         import.meta.env.VITE_USE_MOCK_API === 'true';
+};
+
+// Dynamically import the real API client only if we're not on GitHub Pages
+const getApiClient = async () => {
+  if (isGitHubPages()) {
+    console.log('Using mock API client for GitHub Pages');
+    return mockApiClient;
+  }
+  
+  try {
+    // Try to import the real API client
+    // Note: This should be replaced with your actual API client path
+    const { default: realApiClient } = await import('./real-api-client');
+    console.log('Using real API client');
+    return realApiClient;
+  } catch (error) {
+    // If import fails, fall back to mock API
+    console.warn('Failed to load real API client, falling back to mock:', error);
+    return mockApiClient;
+  }
+};
+
+export default getApiClient;

--- a/src/lib/mock-api/index.ts
+++ b/src/lib/mock-api/index.ts
@@ -1,0 +1,116 @@
+/**
+ * Mock API Service for GitHub Pages
+ * 
+ * This module provides static data for the GitHub Pages deployment
+ * where backend services are not available.
+ */
+
+// Mock market data
+export const mockMarkets = [
+  { symbol: 'BTC/USDT', price: 65432.10, change24h: 2.5, volume24h: 1234567890 },
+  { symbol: 'ETH/USDT', price: 3456.78, change24h: -1.2, volume24h: 987654321 },
+  { symbol: 'SOL/USDT', price: 123.45, change24h: 5.6, volume24h: 456789012 },
+  { symbol: 'BNB/USDT', price: 567.89, change24h: 0.8, volume24h: 345678901 },
+  { symbol: 'XRP/USDT', price: 0.5678, change24h: -2.3, volume24h: 234567890 },
+];
+
+// Mock order book data
+export const mockOrderBook = {
+  'BTC/USDT': {
+    bids: [
+      [65430.5, 1.2],
+      [65429.8, 0.5],
+      [65428.2, 2.3],
+      [65427.1, 1.8],
+      [65426.0, 3.2],
+    ],
+    asks: [
+      [65433.2, 0.8],
+      [65434.5, 1.5],
+      [65435.7, 2.1],
+      [65436.9, 0.7],
+      [65438.2, 1.9],
+    ],
+  },
+};
+
+// Mock recent trades
+export const mockRecentTrades = {
+  'BTC/USDT': [
+    { price: 65432.10, amount: 0.12, side: 'buy', timestamp: Date.now() - 30000 },
+    { price: 65431.50, amount: 0.08, side: 'sell', timestamp: Date.now() - 45000 },
+    { price: 65433.20, amount: 0.25, side: 'buy', timestamp: Date.now() - 60000 },
+    { price: 65430.80, amount: 0.15, side: 'sell', timestamp: Date.now() - 90000 },
+    { price: 65434.10, amount: 0.32, side: 'buy', timestamp: Date.now() - 120000 },
+  ],
+};
+
+// Mock chart data (OHLCV)
+export const mockChartData = {
+  'BTC/USDT': {
+    '1h': Array.from({ length: 24 }, (_, i) => {
+      const basePrice = 65000;
+      const time = Date.now() - (23 - i) * 3600000;
+      const open = basePrice + Math.random() * 1000 - 500;
+      const high = open + Math.random() * 200;
+      const low = open - Math.random() * 200;
+      const close = (open + high + low) / 3 + (Math.random() * 100 - 50);
+      const volume = Math.random() * 100 + 50;
+      return [time, open, high, low, close, volume];
+    }),
+  },
+};
+
+// Mock user data (for demo purposes)
+export const mockUser = {
+  id: 'demo-user',
+  username: 'demo',
+  email: 'demo@example.com',
+  balances: {
+    'USDT': 10000,
+    'BTC': 0.5,
+    'ETH': 5,
+    'SOL': 50,
+  },
+};
+
+// Mock API client
+export const mockApiClient = {
+  // Market data
+  getMarkets: () => Promise.resolve(mockMarkets),
+  getMarketPrice: (symbol: string) => {
+    const market = mockMarkets.find(m => m.symbol === symbol);
+    return Promise.resolve(market?.price || 0);
+  },
+  
+  // Order book
+  getOrderBook: (symbol: string) => {
+    return Promise.resolve(mockOrderBook[symbol as keyof typeof mockOrderBook] || { bids: [], asks: [] });
+  },
+  
+  // Recent trades
+  getRecentTrades: (symbol: string) => {
+    return Promise.resolve(mockRecentTrades[symbol as keyof typeof mockRecentTrades] || []);
+  },
+  
+  // Chart data
+  getChartData: (symbol: string, timeframe: string) => {
+    const symbolData = mockChartData[symbol as keyof typeof mockChartData];
+    if (!symbolData) return Promise.resolve([]);
+    return Promise.resolve(symbolData[timeframe as keyof typeof symbolData] || []);
+  },
+  
+  // User data
+  getUserData: () => Promise.resolve(mockUser),
+  
+  // Mock trading functions (these just return success responses)
+  placeOrder: () => Promise.resolve({ success: true, orderId: 'mock-order-' + Date.now() }),
+  cancelOrder: () => Promise.resolve({ success: true }),
+  
+  // Authentication (always succeeds in demo mode)
+  login: () => Promise.resolve({ success: true, user: mockUser }),
+  register: () => Promise.resolve({ success: true, user: mockUser }),
+  logout: () => Promise.resolve({ success: true }),
+};
+
+export default mockApiClient;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import './styles/crypto-colors.css';
 import './styles/protected-theme-override.css';
 import { AuthProvider } from './contexts/AuthContext';
+import { ConditionalAuthProvider } from './contexts/GitHubPagesAuthContext';
 import { FeatureFlagsProvider } from './config/featureFlags.tsx';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -79,9 +80,11 @@ createRoot(document.getElementById('root')!).render(
   <QueryClientProvider client={queryClient}>
     <BrowserRouter>
       <FeatureFlagsProvider>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
+        <ConditionalAuthProvider>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </ConditionalAuthProvider>
       </FeatureFlagsProvider>
     </BrowserRouter>
   </QueryClientProvider>,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  // Base path for GitHub Pages deployment
+  base: process.env.VITE_BASE_PATH || '/',
   server: {
     host: '::',
     port: 8080,


### PR DESCRIPTION
This commit introduces GitHub Pages deployment capabilities, including:
- Configuration for GitHub Pages base path in vite.config.ts
- GitHub Actions workflow for automated deployment
- Mock API and authentication context for GitHub Pages
- Demo banner to indicate GitHub Pages environment
- Documentation for GitHub Pages deployment and limitations