### PR TITLE
build(gh-pages): add configuration and scripts for GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build with Vite
-        run: npm run build
+      - name: Build with Vite for GitHub Pages
+        run: npm run build:gh-pages
         env:
           # Set base path for GitHub Pages
           VITE_BASE_PATH: '/omnitrade-terminal/'
@@ -53,7 +53,10 @@ jobs:
       - name: Copy essential files to root
         run: |
           cp ./public/placeholder.svg ./dist/
-          cp ./public/404.html ./dist/
+          cp ./public/gh-pages-404.html ./dist/404.html
+          cp ./public/.htaccess ./dist/
+          cp ./public/web.config ./dist/
+          cp ./public/_headers ./dist/
 
       # Update the index.html to use the correct script path for production
       - name: Update index.html for production

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,25 @@
+[build]
+  publish = "dist"
+  command = "npm run build"
+
+# Handle SPA routing
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+# Set proper MIME types
+[[headers]]
+  for = "/*.js"
+  [headers.values]
+    Content-Type = "text/javascript"
+
+[[headers]]
+  for = "/*.mjs"
+  [headers.values]
+    Content-Type = "text/javascript"
+
+[[headers]]
+  for = "/*.svg"
+  [headers.values]
+    Content-Type = "image/svg+xml"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev:all": "concurrently \"npm run start:dev --prefix backend\" \"npm run dev\"",
     "build": "vite build",
     "build:dev": "vite build --mode development",
+    "build:gh-pages": "vite build && node scripts/fix-gh-pages.js",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "lint:backend": "cd backend && eslint . --ext ts --report-unused-disable-directives --max-warnings 0",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,20 @@
+# Proper MIME type for JavaScript modules
+<IfModule mod_mime.c>
+  AddType text/javascript .js
+  AddType text/javascript .mjs
+</IfModule>
+
+# Proper MIME type for SVG files
+<IfModule mod_mime.c>
+  AddType image/svg+xml .svg
+</IfModule>
+
+# Handle SPA routing
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /omnitrade-terminal/
+  RewriteRule ^index\.html$ - [L]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule . /omnitrade-terminal/index.html [L]
+</IfModule>

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,7 @@
+# Set correct MIME types
+/*.js
+  Content-Type: text/javascript
+/*.mjs
+  Content-Type: text/javascript
+/*.svg
+  Content-Type: image/svg+xml

--- a/public/gh-pages-404.html
+++ b/public/gh-pages-404.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OmniTrade - Page Not Found</title>
+    <link rel="icon" href="./placeholder.svg" type="image/svg+xml" />
+    
+    <!-- GitHub Pages SPA routing support -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
+    
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            background-color: #131722;
+            color: white;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            padding: 20px;
+            text-align: center;
+        }
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.1rem;
+            margin-bottom: 2rem;
+            color: #aaa;
+        }
+        .logo {
+            width: 80px;
+            height: 80px;
+            margin-bottom: 2rem;
+            background-color: #1A1A1A;
+            border-radius: 8px;
+            padding: 10px;
+        }
+        .redirect-button {
+            background-color: #6366F1;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+        .redirect-button:hover {
+            background-color: #4F46E5;
+        }
+    </style>
+</head>
+<body>
+    <img src="./placeholder.svg" alt="OmniTrade Logo" class="logo">
+    <h1>OmniTrade Terminal</h1>
+    <p>Redirecting to the main page...</p>
+    <button class="redirect-button" onclick="redirectToHome()">Go to Home Page</button>
+
+    <script>
+        function redirectToHome() {
+            // Get the base URL without the path
+            const baseUrl = window.location.origin;
+            // Redirect to the base path of the GitHub Pages site
+            window.location.href = baseUrl + '/omnitrade-terminal/';
+        }
+        
+        // Auto-redirect after 3 seconds
+        setTimeout(redirectToHome, 3000);
+    </script>
+</body>
+</html>

--- a/public/web.config
+++ b/public/web.config
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <mimeMap fileExtension=".js" mimeType="text/javascript" />
+      <mimeMap fileExtension=".mjs" mimeType="text/javascript" />
+      <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+    </staticContent>
+    <rewrite>
+      <rules>
+        <rule name="SPA Routes" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="/omnitrade-terminal/index.html" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>

--- a/scripts/fix-gh-pages.js
+++ b/scripts/fix-gh-pages.js
@@ -1,0 +1,52 @@
+// This script fixes common GitHub Pages issues
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get the current directory
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const distDir = path.join(__dirname, '..', 'dist');
+
+console.log('Fixing GitHub Pages issues...');
+
+// 1. Check if the placeholder.svg exists
+const placeholderPath = path.join(distDir, 'placeholder.svg');
+if (!fs.existsSync(placeholderPath)) {
+  console.error('❌ placeholder.svg not found in dist directory');
+  console.log('Creating a simple SVG placeholder...');
+  
+  // Create a simple SVG placeholder
+  const simpleSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#333"/>
+  <text x="50" y="50" font-family="Arial" font-size="12" fill="white" text-anchor="middle" dominant-baseline="middle">Placeholder</text>
+</svg>`;
+  
+  fs.writeFileSync(placeholderPath, simpleSvg);
+  console.log('✅ Created placeholder.svg');
+}
+
+// 2. Check the index.html file for correct paths
+const indexPath = path.join(distDir, 'index.html');
+let indexContent = fs.readFileSync(indexPath, 'utf8');
+
+// Fix asset paths
+const fixedContent = indexContent
+  .replace(/src="\/omnitrade-terminal\/assets\//g, 'src="./assets/')
+  .replace(/href="\/omnitrade-terminal\/assets\//g, 'href="./assets/')
+  .replace(/src="\/assets\//g, 'src="./assets/')
+  .replace(/href="\/assets\//g, 'href="./assets/');
+
+if (fixedContent !== indexContent) {
+  fs.writeFileSync(indexPath, fixedContent);
+  console.log('✅ Fixed asset paths in index.html');
+}
+
+// 3. Create a .nojekyll file
+const nojekyllPath = path.join(distDir, '.nojekyll');
+if (!fs.existsSync(nojekyllPath)) {
+  fs.writeFileSync(nojekyllPath, '');
+  console.log('✅ Created .nojekyll file');
+}
+
+console.log('GitHub Pages fixes complete!');

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,34 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*).js",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/javascript"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).mjs",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/javascript"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).svg",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "image/svg+xml"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add necessary configuration files and scripts to ensure proper deployment to GitHub Pages. This includes setting correct MIME types, handling SPA routing, and fixing asset paths in the build process. The changes also include a custom 404 page for GitHub Pages and a script to automate fixes for common deployment issues.