### PR TITLE
docs: add test pages and scripts to prevent 404 errors

### DIFF
--- a/docs/image-test.html
+++ b/docs/image-test.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Test</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            background-color: #131722;
+            color: white;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            padding: 20px;
+            text-align: center;
+        }
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.1rem;
+            margin-bottom: 2rem;
+            color: #aaa;
+        }
+        .image-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            margin-top: 20px;
+        }
+        .image-item {
+            margin: 10px;
+            padding: 10px;
+            background-color: rgba(0,0,0,0.3);
+            border-radius: 8px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Image Test Page</h1>
+    <p>This page tests if SVG files are being served correctly.</p>
+    
+    <div class="image-container">
+        <div class="image-item">
+            <p>SVG as img tag:</p>
+            <img src="placeholder.svg" alt="Placeholder" width="100" height="100" />
+        </div>
+        
+        <div class="image-item">
+            <p>SVG as object tag:</p>
+            <object data="placeholder.svg" type="image/svg+xml" width="100" height="100"></object>
+        </div>
+        
+        <div class="image-item">
+            <p>SVG as embed tag:</p>
+            <embed src="placeholder.svg" type="image/svg+xml" width="100" height="100" />
+        </div>
+        
+        <div class="image-item">
+            <p>Inline SVG:</p>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect width="24" height="24" fill="#2A2A2A" rx="4"/>
+                <circle cx="12" cy="12" r="8" fill="none" stroke="#888"/>
+                <path d="M12 8v8M8 12h8" stroke="#888"/>
+            </svg>
+        </div>
+    </div>
+    
+    <p><a href="index.html" style="color: #6366F1; text-decoration: none;">Back to Home</a></p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,6 +110,8 @@
     <div class="button-group">
         <a href="https://github.com/ArtCenter1/omnitrade-terminal" class="button">View on GitHub</a>
         <a href="test.html" class="button">Test Page</a>
+        <a href="script-test.html" class="button">Script Test</a>
+        <a href="image-test.html" class="button">Image Test</a>
     </div>
 
     <div class="status">
@@ -132,7 +134,14 @@
         // Set the last updated time
         document.getElementById('last-updated').textContent = new Date().toLocaleString();
     </script>
-    <!-- Include the main.tsx script to prevent 404 errors -->
-    <script src="main.tsx" type="text/javascript"></script>
+    <!-- Include the main.js script to prevent 404 errors -->
+    <script src="main.js" type="text/javascript"></script>
+
+    <!-- Inline version of main.tsx content as a fallback -->
+    <script>
+        // This is a placeholder script to prevent 404 errors
+        console.log('OmniTrade Terminal - GitHub Pages Demo (Inline)');
+        console.log('This is a simplified version without the full React application.');
+    </script>
 </body>
 </html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,0 +1,3 @@
+// This is a placeholder file to prevent 404 errors
+console.log('OmniTrade Terminal - GitHub Pages Demo');
+console.log('This is a simplified version without the full React application.');

--- a/docs/main.txt
+++ b/docs/main.txt
@@ -1,0 +1,3 @@
+// This is a placeholder file to prevent 404 errors
+console.log('OmniTrade Terminal - GitHub Pages Demo');
+console.log('This is a simplified version without the full React application.');

--- a/docs/script-test.html
+++ b/docs/script-test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Script Test</title>
+</head>
+<body>
+    <h1>Script Test Page</h1>
+    <p>This page tests if JavaScript files are being served correctly.</p>
+    <p>Check the browser console for messages.</p>
+
+    <p><a href="main.txt" style="color: blue;">View main.txt</a> | <a href="main.js" style="color: blue;">View main.js</a></p>
+
+    <script>
+        console.log('Inline script is working');
+    </script>
+
+    <script src="main.js"></script>
+</body>
+</html>

--- a/docs/test.html
+++ b/docs/test.html
@@ -51,8 +51,15 @@
         setInterval(updateTime, 1000);
     </script>
 
-    <!-- Include the main.tsx script to prevent 404 errors -->
-    <script src="main.tsx" type="text/javascript"></script>
+    <!-- Include the main.js script to prevent 404 errors -->
+    <script src="main.js" type="text/javascript"></script>
+
+    <!-- Inline version of main.tsx content as a fallback -->
+    <script>
+        // This is a placeholder script to prevent 404 errors
+        console.log('OmniTrade Terminal - GitHub Pages Demo (Inline)');
+        console.log('This is a simplified version without the full React application.');
+    </script>
 
     <!-- Add an image tag to test the placeholder.svg -->
     <div style="margin-top: 20px;">


### PR DESCRIPTION
Add new HTML pages (script-test.html, image-test.html) and placeholder scripts (main.js, main.txt) to test and ensure proper serving of assets on GitHub Pages. Update existing pages to reference the new scripts and add navigation links for the new test pages.