### PR TITLE
perf: increase cache durations and adjust rate limiting for stability

### DIFF
--- a/backend/src/market-data/coingecko-proxy.controller.ts
+++ b/backend/src/market-data/coingecko-proxy.controller.ts
@@ -26,61 +26,61 @@ export class CoinGeckoProxyController {
 
   // Request throttling
   private requestTimestamps: number[] = [];
-  private readonly MAX_REQUESTS_PER_MINUTE = 30; // Very conservative limit for free tier
+  private readonly MAX_REQUESTS_PER_MINUTE = 15; // Extremely conservative limit for free tier (reduced from 30)
   private readonly REQUEST_WINDOW_MS = 60000; // 1 minute window
 
   // Cache TTLs for different endpoint types (in seconds)
   private readonly cacheTtls: Record<string, number> = {
     // Market data endpoints
-    'coins/markets': 1800, // 30 minutes (increased from 10)
-    'coins/list': 14400, // 4 hours (increased from 2)
-    'coins/categories/list': 14400, // 4 hours (increased from 2)
-    'coins/categories': 14400, // 4 hours (increased from 2)
+    'coins/markets': 3600, // 60 minutes (increased from 30)
+    'coins/list': 28800, // 8 hours (increased from 4)
+    'coins/categories/list': 28800, // 8 hours (increased from 4)
+    'coins/categories': 28800, // 8 hours (increased from 4)
 
     // Static data that rarely changes
-    'coins/*/contract/*': 7200, // 2 hours (increased from 1)
-    'coins/*/history': 172800, // 48 hours for historical data (increased from 24)
-    'asset_platforms': 172800, // 48 hours (increased from 24)
-    'exchanges/list': 172800, // 48 hours (increased from 24)
+    'coins/*/contract/*': 14400, // 4 hours (increased from 2)
+    'coins/*/history': 259200, // 72 hours for historical data (increased from 48)
+    'asset_platforms': 259200, // 72 hours (increased from 48)
+    'exchanges/list': 259200, // 72 hours (increased from 48)
 
     // Price data endpoints (more frequent updates needed)
-    'simple/price': 300, // 5 minutes (increased from 2)
-    'simple/token_price': 300, // 5 minutes (increased from 2)
-    'coins/*/tickers': 180, // 3 minutes (increased from 1)
+    'simple/price': 600, // 10 minutes (increased from 5)
+    'simple/token_price': 600, // 10 minutes (increased from 5)
+    'coins/*/tickers': 600, // 10 minutes (increased from 3)
 
     // OHLC and chart data
-    'coins/*/market_chart': 1800, // 30 minutes (increased from 10)
-    'coins/*/ohlc': 1800, // 30 minutes (increased from 10)
+    'coins/*/market_chart': 3600, // 60 minutes (increased from 30)
+    'coins/*/ohlc': 3600, // 60 minutes (increased from 30)
 
     // Default for other endpoints
-    default: 300, // 5 minutes (increased from 2)
+    default: 600, // 10 minutes (increased from 5)
   };
 
   // Stale TTLs - how long to consider data usable after expiration (in seconds)
   private readonly staleTtls: Record<string, number> = {
     // Market data endpoints can be stale for longer
-    'coins/markets': 7200, // 2 hours stale data is acceptable (increased from 1 hour)
-    'coins/list': 172800, // 48 hours (increased from 24)
-    'coins/categories/list': 172800, // 48 hours (increased from 24)
-    'coins/categories': 172800, // 48 hours (increased from 24)
+    'coins/markets': 14400, // 4 hours stale data is acceptable (increased from 2 hours)
+    'coins/list': 259200, // 72 hours (increased from 48)
+    'coins/categories/list': 259200, // 72 hours (increased from 48)
+    'coins/categories': 259200, // 72 hours (increased from 48)
 
     // Static data can be stale for very long
-    'coins/*/contract/*': 172800, // 48 hours (increased from 24)
-    'coins/*/history': 1209600, // 14 days (increased from 7)
-    'asset_platforms': 1209600, // 14 days (increased from 7)
-    'exchanges/list': 1209600, // 14 days (increased from 7)
+    'coins/*/contract/*': 259200, // 72 hours (increased from 48)
+    'coins/*/history': 2592000, // 30 days (increased from 14)
+    'asset_platforms': 2592000, // 30 days (increased from 14)
+    'exchanges/list': 2592000, // 30 days (increased from 14)
 
     // Price data should not be stale for too long, but we can still increase a bit
-    'simple/price': 600, // 10 minutes (increased from 5)
-    'simple/token_price': 600, // 10 minutes (increased from 5)
-    'coins/*/tickers': 600, // 10 minutes (increased from 5)
+    'simple/price': 1800, // 30 minutes (increased from 10)
+    'simple/token_price': 1800, // 30 minutes (increased from 10)
+    'coins/*/tickers': 1800, // 30 minutes (increased from 10)
 
     // OHLC and chart data
-    'coins/*/market_chart': 7200, // 2 hours (increased from 1)
-    'coins/*/ohlc': 7200, // 2 hours (increased from 1)
+    'coins/*/market_chart': 14400, // 4 hours (increased from 2)
+    'coins/*/ohlc': 14400, // 4 hours (increased from 2)
 
     // Default for other endpoints
-    default: 1800, // 30 minutes (increased from 10)
+    default: 3600, // 60 minutes (increased from 30)
   };
 
   // Endpoint priority levels (higher number = higher priority)
@@ -128,9 +128,9 @@ export class CoinGeckoProxyController {
   ) {
     // Register the CoinGecko circuit breaker with custom config
     this.circuitBreakerService.registerCircuit(this.CIRCUIT_NAME, {
-      failureThreshold: 3, // Reduced from 5 to be more sensitive to rate limiting
-      resetTimeout: 120 * 1000, // 2 minutes (increased from 1 minute)
-      halfOpenMaxRequests: 1, // Reduced from 3 to be more cautious when testing if service is back
+      failureThreshold: 2, // Reduced from 3 to be even more sensitive to rate limiting
+      resetTimeout: 300 * 1000, // 5 minutes (increased from 2 minutes)
+      halfOpenMaxRequests: 1, // Keep at 1 to be cautious when testing if service is back
     });
 
     // Start processing the queue

--- a/src/services/coinGeckoService.ts
+++ b/src/services/coinGeckoService.ts
@@ -25,7 +25,7 @@ const coinDataCache: Record<string, CoinGeckoData> = {};
 const symbolToIdCache: Record<string, string> = {};
 let allCoinsCache: CoinGeckoData[] = [];
 let lastCacheUpdate = 0;
-const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes (increased from 5)
+const CACHE_DURATION = 60 * 60 * 1000; // 60 minutes (increased from 15)
 
 /**
  * Helper function to retry API calls with exponential backoff

--- a/src/services/enhancedCoinGeckoService.ts
+++ b/src/services/enhancedCoinGeckoService.ts
@@ -19,17 +19,17 @@ console.log(`- Pro API URL: ${PRO_API_URL}`);
 console.log(`- API Key available: ${API_KEY ? 'Yes' : 'No'}`);
 
 // Rate limiting configuration
-const PUBLIC_RATE_LIMIT = 8; // requests per minute (reduced further for safety)
-const PRO_RATE_LIMIT = 25; // requests per minute (reduced further for safety)
+const PUBLIC_RATE_LIMIT = 5; // requests per minute (reduced from 8 for extreme safety)
+const PRO_RATE_LIMIT = 15; // requests per minute (reduced from 25 for extreme safety)
 
 // Throttling configuration
-const THROTTLE_DELAY = 1000; // ms between requests (increased from 500ms)
+const THROTTLE_DELAY = 2000; // ms between requests (increased from 1000ms)
 let lastRequestTime = 0;
 
 // Circuit breaker configuration
 const CIRCUIT_BREAKER = {
-  FAILURE_THRESHOLD: 5, // Number of failures before opening circuit
-  RESET_TIMEOUT: 60 * 1000, // 1 minute timeout before trying again
+  FAILURE_THRESHOLD: 3, // Number of failures before opening circuit (reduced from 5)
+  RESET_TIMEOUT: 300 * 1000, // 5 minutes timeout before trying again (increased from 1 minute)
   state: 'CLOSED', // CLOSED, OPEN, HALF_OPEN
   failures: 0,
   lastFailure: 0,
@@ -38,18 +38,18 @@ const CIRCUIT_BREAKER = {
 
 // Cache durations (in milliseconds)
 const CACHE_DURATIONS = {
-  COINS: 10 * 60 * 1000, // 10 minutes (increased from 5)
-  MARKETS: 2 * 60 * 1000, // 2 minutes (increased from 1)
-  TICKERS: 30 * 1000, // 30 seconds (increased from 10)
-  ORDERBOOK: 15 * 1000, // 15 seconds (increased from 5)
-  PRICE: 30 * 1000, // 30 seconds (increased from 10)
+  COINS: 30 * 60 * 1000, // 30 minutes (increased from 10)
+  MARKETS: 10 * 60 * 1000, // 10 minutes (increased from 2)
+  TICKERS: 5 * 60 * 1000, // 5 minutes (increased from 30 seconds)
+  ORDERBOOK: 60 * 1000, // 1 minute (increased from 15 seconds)
+  PRICE: 5 * 60 * 1000, // 5 minutes (increased from 30 seconds)
 
   // Add stale durations - how long to use expired cache data
-  STALE_COINS: 60 * 60 * 1000, // 1 hour
-  STALE_MARKETS: 10 * 60 * 1000, // 10 minutes
-  STALE_TICKERS: 2 * 60 * 1000, // 2 minutes
-  STALE_ORDERBOOK: 1 * 60 * 1000, // 1 minute
-  STALE_PRICE: 2 * 60 * 1000, // 2 minutes
+  STALE_COINS: 4 * 60 * 60 * 1000, // 4 hours (increased from 1 hour)
+  STALE_MARKETS: 60 * 60 * 1000, // 1 hour (increased from 10 minutes)
+  STALE_TICKERS: 30 * 60 * 1000, // 30 minutes (increased from 2 minutes)
+  STALE_ORDERBOOK: 10 * 60 * 1000, // 10 minutes (increased from 1 minute)
+  STALE_PRICE: 30 * 60 * 1000, // 30 minutes (increased from 2 minutes)
 };
 
 // Interface for CoinGecko coin data
@@ -127,7 +127,7 @@ const cache = {
 // Constants for persistent cache
 const SYMBOL_CACHE_KEY = 'coingecko_symbol_to_id_cache';
 const SYMBOL_CACHE_TIMESTAMP_KEY = 'coingecko_symbol_to_id_cache_timestamp';
-const SYMBOL_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+const SYMBOL_CACHE_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 days (increased from 24 hours)
 
 // Initialize symbol to ID cache from localStorage if available
 function initializeSymbolCache() {


### PR DESCRIPTION
Adjust cache durations, rate limits, and circuit breaker configurations to improve system stability and reduce API call frequency. These changes aim to minimize the risk of rate limiting and enhance the reliability of the service by extending cache lifetimes and tightening request throttling.