### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix logic error in exchange ID validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Hardcoded encryption keys (`super_secret_key`) and static Initialization Vectors (all zeros) were used in `ExchangeApiKeyService` and `PortfolioService` to "encrypt" sensitive exchange API keys and secrets.
 **Learning:** This implementation provided only a false sense of security (security theater). A static IV means the same plaintext always results in the same ciphertext, and a hardcoded key is easily discoverable by anyone with access to the source code.
 **Prevention:** Always use environment-driven secrets for encryption keys and ensure each encryption operation uses a unique, random IV. Store the IV alongside the ciphertext.
+
+## 2025-05-22 - Logic Error in Exchange ID Validation
+**Vulnerability:** The `in` operator was incorrectly used on the `ccxt.exchanges` array to validate user-provided exchange IDs. In JavaScript/TypeScript, `in` checks for property keys (indices in an array), not values. This resulted in legitimate exchange IDs failing validation.
+**Learning:** Confusing the `in` operator with value membership checks is a common logic error that can break security-critical input validation.
+**Prevention:** Always use `.includes()` for checking if a value exists within an array. When working with third-party libraries like `ccxt`, be aware that TypeScript definitions might sometimes be overly complex, requiring explicit type casting (e.g., `as unknown as string[]`) to use standard array methods safely.

--- a/backend/src/exchange-api-key/__tests__/exchange-api-key.service.spec.ts
+++ b/backend/src/exchange-api-key/__tests__/exchange-api-key.service.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExchangeApiKeyService } from '../exchange-api-key.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import * as ccxt from 'ccxt';
+import * as encryptionUtils from '../../utils/encryption.util';
+
+jest.mock('ccxt', () => {
+  return {
+    __esModule: true,
+    exchanges: ['binance', 'kraken'],
+    binance: jest.fn().mockImplementation(() => ({
+      fetchBalance: jest.fn().mockResolvedValue({}),
+    })),
+    AuthenticationError: class AuthenticationError extends Error {},
+    ExchangeNotAvailable: class ExchangeNotAvailable extends Error {},
+    NetworkError: class NetworkError extends Error {},
+  };
+});
+
+jest.mock('../../utils/encryption.util', () => ({
+  decrypt: jest.fn((text) => text.replace('encrypted-', '')),
+  encrypt: jest.fn((text) => `encrypted-${text}`),
+}));
+
+describe('ExchangeApiKeyService', () => {
+  let service: ExchangeApiKeyService;
+  let prisma: PrismaService;
+
+  const mockPrismaService = {
+    userApiKey: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExchangeApiKeyService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ExchangeApiKeyService>(ExchangeApiKeyService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  describe('testApiKey', () => {
+    it('should succeed when exchangeId is in ccxt.exchanges', async () => {
+      const userId = 'user-1';
+      const apiKeyId = 'key-1';
+      const mockKey = {
+        user_id: userId,
+        exchange_id: 'binance',
+        api_key_encrypted: 'encrypted-api-key',
+        api_secret_encrypted: 'encrypted-api-secret',
+      };
+
+      (prisma.userApiKey.findUnique as jest.Mock).mockResolvedValue(mockKey);
+
+      const result = await service.testApiKey(userId, apiKeyId);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('connection successful');
+    });
+
+    it('should fail when exchangeId is NOT in ccxt.exchanges', async () => {
+      const userId = 'user-1';
+      const apiKeyId = 'key-1';
+      const mockKey = {
+        user_id: userId,
+        exchange_id: 'invalid-exchange',
+        api_key_encrypted: 'encrypted-api-key',
+        api_secret_encrypted: 'encrypted-api-secret',
+      };
+
+      (prisma.userApiKey.findUnique as jest.Mock).mockResolvedValue(mockKey);
+
+      const result = await service.testApiKey(userId, apiKeyId);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('is not supported by the validation library');
+    });
+  });
+});

--- a/backend/src/exchange-api-key/exchange-api-key.service.ts
+++ b/backend/src/exchange-api-key/exchange-api-key.service.ts
@@ -130,9 +130,8 @@ export class ExchangeApiKeyService {
       // Note: Assumes the stored exchange_id is compatible or mapped correctly.
       const exchangeId = (key as UserApiKey).exchange_id.toLowerCase(); // Example: 'binance', 'kraken'
 
-      // Check if the exchange is supported by ccxt by checking key existence
-      if (!(exchangeId in ccxt.exchanges)) {
-        // Added newline for formatting
+      // Check if the exchange is supported by ccxt
+      if (!(ccxt.exchanges as unknown as string[]).includes(exchangeId)) {
         throw new Error(
           `Exchange '${(key as UserApiKey).exchange_id}' is not supported by the validation library.`,
         );


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Logic error using the `in` operator on the `ccxt.exchanges` array in `ExchangeApiKeyService.ts`. In JavaScript, `in` checks for property keys (indices) in an array, not values, causing valid exchange IDs to fail validation.
🎯 Impact: Legitimate exchange IDs were incorrectly rejected, breaking the API key testing functionality and potentially creating edge-case bypasses if numeric indices were supplied.
🔧 Fix: Replaced `!(exchangeId in ccxt.exchanges)` with `!(ccxt.exchanges as unknown as string[]).includes(exchangeId)`.
✅ Verification: Added a new test suite `backend/src/exchange-api-key/__tests__/exchange-api-key.service.spec.ts` that reproduces the failure and verifies the fix for both valid and invalid exchange IDs. Existing tests also pass.

---
*PR created automatically by Jules for task [10237751974604730151](https://jules.google.com/task/10237751974604730151) started by @ArtCenter1*