### PR TITLE
🛡️ Sentinel: Add rate limiting to exchange API key test endpoint

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,7 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import {
   globalRateLimiter,
   passwordResetLimiter,
+  apiKeyTestLimiter,
 } from './middleware/rate-limiter.middleware';
 
 async function bootstrap() {
@@ -64,6 +65,7 @@ async function bootstrap() {
 
   // Security: Specific rate limiting for sensitive endpoints
   app.use('/api/auth/password-reset-request', passwordResetLimiter);
+  app.use('/api/exchange-api-keys/:id/test', apiKeyTestLimiter);
 
   // Apply ValidationPipe globally
   app.useGlobalPipes(

--- a/backend/src/middleware/rate-limiter.middleware.ts
+++ b/backend/src/middleware/rate-limiter.middleware.ts
@@ -20,3 +20,16 @@ export const globalRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+/**
+ * Rate limiter for testing exchange API keys.
+ * Limits each IP to 10 requests per 15-minute window.
+ */
+export const apiKeyTestLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // Limit each IP to 10 requests per windowMs
+  message:
+    'Too many API key test requests from this IP, please try again after 15 minutes',
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/backend/test/api-key-test-limiter.e2e-spec.ts
+++ b/backend/test/api-key-test-limiter.e2e-spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from './../src/app.module';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import {
+  globalRateLimiter,
+  apiKeyTestLimiter,
+} from './../src/middleware/rate-limiter.middleware';
+
+describe('API Key Test Rate Limiting (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+
+    // Apply the same configuration as in main.ts
+    app.getHttpAdapter().getInstance().set('trust proxy', 1);
+    app.use(globalRateLimiter);
+    app.use('/api/exchange-api-keys/:id/test', apiKeyTestLimiter);
+    app.setGlobalPrefix('api');
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const apiKeyId = 'test-api-key-id';
+  const endpoint = `/api/exchange-api-keys/${apiKeyId}/test`;
+
+  it('allows 10 requests to the API key test endpoint', async () => {
+    for (let i = 0; i < 10; i++) {
+      // We expect 401 Unauthorized because we are not sending a token,
+      // but the rate limiter should let it pass through to the auth guard.
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .set('X-Forwarded-For', '10.0.0.1')
+        .expect((res) => {
+          if (res.status === 429) {
+            throw new Error(`Rate limited at request ${i + 1}`);
+          }
+        });
+    }
+  });
+
+  it('blocks the 11th request with 429', async () => {
+    // 11th request should be rate limited
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .set('X-Forwarded-For', '10.0.0.1')
+      .expect(429);
+  });
+
+  it('allows requests from a different IP', async () => {
+    // Different IP should not be blocked
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .set('X-Forwarded-For', '10.0.0.2')
+      .expect((res) => {
+        if (res.status === 429) {
+          throw new Error('Rate limited for a new IP');
+        }
+      });
+  });
+});

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
@@ -45,7 +45,7 @@ describe('/auth/password-reset-request rate limiting (e2e)', () => {
         .post(endpoint)
         .set('X-Forwarded-For', '1.2.3.4')
         .send({ email: testEmail })
-        .expect((res) => {
+        .expect((res: any) => {
           // Accept 200, 201, or 204 (depending on implementation)
           if (![200, 201, 204].includes(res.status)) {
             throw new Error(`Unexpected status: ${res.status}`);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Proactive defense against brute-force and resource exhaustion attacks on the exchange API key test endpoint.
🎯 Impact: Without rate limiting, an attacker could attempt to brute-force API credentials or cause resource exhaustion on the server/third-party exchanges.
🔧 Fix: Added `apiKeyTestLimiter` (10 requests per 15 minutes) to `backend/src/middleware/rate-limiter.middleware.ts` and applied it to the `/api/exchange-api-keys/:id/test` endpoint in `backend/src/main.ts`.
✅ Verification: Created a new E2E test `backend/test/api-key-test-limiter.e2e-spec.ts` that verifies the rate limiting logic. Also verified by running existing exchange-api-key unit tests.

---
*PR created automatically by Jules for task [17597456789523053154](https://jules.google.com/task/17597456789523053154) started by @ArtCenter1*