### PR TITLE
🛡️ Sentinel: [HIGH] Add authentication to market data proxy endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The `testApiKey` endpoint was leaking detailed library-specific error messages (from `ccxt`) to the client and lacked specific rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Returning raw exception messages from third-party libraries can expose backend implementation details or network topology. Furthermore, sensitive operations like credential validation must always have dedicated rate limits beyond the global API limit.
 **Prevention:** Always map library-specific errors to generic, safe messages for the client. Implement granular rate limiting for all endpoints that perform expensive or security-sensitive operations. Ensure E2E tests for rate limiting correctly simulate production conditions by setting `trust proxy` and matching global route prefixes.
+
+## 2026-05-02 - Public Proxy Endpoints Exposing API Quota
+**Vulnerability:** Market data proxy endpoints (`/api/proxy/coingecko/*` and `/api/proxy/binance-testnet/*`) were accessible without authentication. This allowed any external party to use the application's server as a proxy, consuming its API rate limit and potential pro-tier credits.
+**Learning:** Proxy endpoints are often overlooked during security audits. While they seem "read-only", they expose the server's identity and its associated third-party service quotas to the public.
+**Prevention:** All proxy endpoints must be protected by authentication guards, even if they only provide access to public market data, to protect the application's infrastructure and service quotas from abuse.

--- a/backend/src/market-data/binance-testnet-proxy.controller.ts
+++ b/backend/src/market-data/binance-testnet-proxy.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, All, Req, Logger } from '@nestjs/common';
+import { Controller, All, Req, Logger, UseGuards } from '@nestjs/common';
 import axios from 'axios';
 import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('proxy/binance-testnet')
+@UseGuards(JwtAuthGuard)
 export class BinanceTestnetProxyController {
   private readonly logger = new Logger(BinanceTestnetProxyController.name);
   private readonly baseUrl = 'https://testnet.binance.vision';

--- a/backend/src/market-data/coingecko-proxy.controller.ts
+++ b/backend/src/market-data/coingecko-proxy.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Param, All, Req, Logger, HttpException } from '@nestjs/common';
+import { Controller, Param, All, Req, Logger, HttpException, UseGuards } from '@nestjs/common';
 import axios from 'axios';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Request } from 'express';
 import { RedisService } from '../redis/redis.service';
 import { CircuitBreakerService, CircuitBreakerState } from './circuit-breaker.service';
@@ -18,6 +19,7 @@ interface ErrorResponse {
 }
 
 @Controller('proxy/coingecko')
+@UseGuards(JwtAuthGuard)
 export class CoinGeckoProxyController {
   private readonly logger = new Logger(CoinGeckoProxyController.name);
   private readonly baseUrl =

--- a/backend/test/proxy-auth.e2e-spec.ts
+++ b/backend/test/proxy-auth.e2e-spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('Proxy Authentication (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('CoinGecko Proxy', () => {
+    it('should return 401 when accessing without token', async () => {
+      await request(app.getHttpServer() as unknown as import('http').Server)
+        .get('/api/proxy/coingecko/coins/list')
+        .expect(401);
+    });
+  });
+
+  describe('Binance Testnet Proxy', () => {
+    it('should return 401 when accessing without token', async () => {
+      await request(app.getHttpServer() as unknown as import('http').Server)
+        .get('/api/proxy/binance-testnet/api/v3/ping')
+        .expect(401);
+    });
+  });
+});


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Market data proxy endpoints were publicly accessible.
🎯 Impact: Unauthorized third parties could use the application's server to proxy their own requests, potentially exhausting the application's API rate limits or consuming paid credits.
🔧 Fix: Added @UseGuards(JwtAuthGuard) to both proxy controllers in the backend.
✅ Verification: Created backend/test/proxy-auth.e2e-spec.ts which confirms that unauthenticated requests to these endpoints return 401 Unauthorized. Verified with npm run test:e2e.

---
*PR created automatically by Jules for task [10171137262193756459](https://jules.google.com/task/10171137262193756459) started by @ArtCenter1*