### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CoinGecko API key leakage

### DIFF
--- a/backend/src/market-data/coingecko-proxy.controller.ts
+++ b/backend/src/market-data/coingecko-proxy.controller.ts
@@ -342,11 +342,6 @@ export class CoinGeckoProxyController {
       // Copy query parameters
       const params = { ...req.query };
 
-      // Add API key if available
-      if (this.apiKey) {
-        params['x_cg_pro_api_key'] = this.apiKey;
-      }
-
       // Create a cache key from the URL and parameters
       const cacheKey = `coingecko:${endpoint}:${JSON.stringify(params)}`;
 


### PR DESCRIPTION
Fixed a critical secret leakage vulnerability in the `CoinGeckoProxyController`. Previously, the `COINGECKO_API_KEY` was being appended to the request's query parameters and consequently included in the Redis cache keys. This exposed the sensitive key in plain text within URLs, logs, and the shared Redis instance.

The fix involves:
1. Removing the logic that adds the key to the `params` object in the `proxyRequest` method.
2. Confirming that the `makeRequestWithRetry` method already correctly handles the key via the secure `x-cg-pro-api-key` HTTP header.

This change ensures that the authentication remains functional while strictly adhering to secure secret handling practices. Verified the fix using a temporary unit test that inspected the cache keys generated during proxy requests.

---
*PR created automatically by Jules for task [12622063127487828955](https://jules.google.com/task/12622063127487828955) started by @ArtCenter1*