### PR TITLE
🛡️ Sentinel: [HIGH] Fix shared rate limit bucket for anonymous users

### DIFF
--- a/backend/src/market-data/__tests__/rate-limit.middleware.spec.ts
+++ b/backend/src/market-data/__tests__/rate-limit.middleware.spec.ts
@@ -24,14 +24,18 @@ interface MockRequest {
 
 describe('RateLimitMiddleware', () => {
   let middleware: RateLimitMiddleware;
-  let req: MockRequest;
+  let req: MockRequest & { ip?: string };
   let res: jest.Mocked<import('express').Response>;
   let next: jest.Mock;
+  const mockRedisService = {
+    incr: mockIncr,
+    expire: mockExpire,
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    middleware = new RateLimitMiddleware();
-    req = { header: jest.fn() };
+    middleware = new RateLimitMiddleware(mockRedisService as any);
+    req = { header: jest.fn(), ip: '127.0.0.1' };
     res = undefined as unknown as jest.Mocked<import('express').Response>;
     next = jest.fn();
   });
@@ -77,8 +81,9 @@ describe('RateLimitMiddleware', () => {
     ).rejects.toThrow(HttpException);
   });
 
-  it('enforces lower limit for anonymous users', async () => {
+  it('enforces lower limit for anonymous users using IP', async () => {
     req.header.mockReturnValue(undefined);
+    req.ip = '192.168.1.1';
     mockIncr.mockResolvedValue(11);
 
     await expect(
@@ -88,6 +93,8 @@ describe('RateLimitMiddleware', () => {
         next,
       ),
     ).rejects.toThrow(HttpException);
+
+    expect(mockIncr).toHaveBeenCalledWith('rate_limit:192.168.1.1');
   });
 
   it('does not set TTL if not first request', async () => {

--- a/backend/src/market-data/rate-limit.middleware.ts
+++ b/backend/src/market-data/rate-limit.middleware.ts
@@ -15,9 +15,10 @@ export class RateLimitMiddleware implements NestMiddleware {
 
   async use(req: Request, res: Response, next: NextFunction) {
     try {
-      const apiKey = req.header('x-api-key') || 'anonymous';
-      const key = `rate_limit:${apiKey}`;
-      const limit = apiKey === 'anonymous' ? 10 : 100; // 10 req/min anonymous, 100 req/min with key
+      const apiKey = req.header('x-api-key');
+      // Use IP address for anonymous users to prevent shared rate limit exhaustion (DoS risk)
+      const key = apiKey ? `rate_limit:${apiKey}` : `rate_limit:${req.ip}`;
+      const limit = !apiKey ? 10 : 100; // 10 req/min anonymous (per IP), 100 req/min with key
       const ttlSeconds = 60;
 
       const current = await this.redisService.incr(key);


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix shared rate limit bucket for anonymous users

The `RateLimitMiddleware` used a hardcoded 'anonymous' string as a key in Redis when an API key was missing. This created a shared bucket for all unauthenticated users, allowing a single malicious or high-traffic actor to exhaust the rate limit for everyone (Denial of Service).

This fix changes the fallback key to use the requester's IP address (`req.ip`), ensuring per-IP rate limiting for anonymous users and providing better isolation and resource protection.

🚨 Severity: HIGH
💡 Vulnerability: Shared Resource Exhaustion (DoS)
🎯 Impact: One user can block all anonymous access to market data endpoints.
🔧 Fix: Used `req.ip` as the rate limit key for unauthenticated requests.
✅ Verification: Ran updated unit tests in `backend/src/market-data/__tests__/rate-limit.middleware.spec.ts`.

---
*PR created automatically by Jules for task [12594111707243855057](https://jules.google.com/task/12594111707243855057) started by @ArtCenter1*