### PR TITLE
🛡️ Sentinel: Fix global rate limit bucket exhaustion in MarketData

### DIFF
--- a/backend/src/market-data/__tests__/rate-limit.middleware.spec.ts
+++ b/backend/src/market-data/__tests__/rate-limit.middleware.spec.ts
@@ -1,106 +1,101 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
 import { RateLimitMiddleware } from '../rate-limit.middleware';
-import Redis from 'ioredis';
 import { HttpException } from '@nestjs/common';
-
-jest.mock('ioredis');
-
-const mockIncr = jest.fn();
-const mockExpire = jest.fn();
-
-interface MockRequest {
-  header: jest.Mock;
-}
-
-(
-  Redis as unknown as {
-    mockImplementation: (
-      impl: () => { incr: jest.Mock; expire: jest.Mock },
-    ) => void;
-  }
-).mockImplementation(() => ({
-  incr: mockIncr,
-  expire: mockExpire,
-}));
+import { RedisService } from '../../redis/redis.service';
 
 describe('RateLimitMiddleware', () => {
   let middleware: RateLimitMiddleware;
-  let req: MockRequest;
-  let res: jest.Mocked<import('express').Response>;
+  let redisService: jest.Mocked<RedisService>;
+  let req: any;
+  let res: any;
   let next: jest.Mock;
 
   beforeEach(() => {
-    jest.clearAllMocks();
-    middleware = new RateLimitMiddleware();
-    req = { header: jest.fn() };
-    res = undefined as unknown as jest.Mocked<import('express').Response>;
+    redisService = {
+      incr: jest.fn(),
+      expire: jest.fn(),
+    } as any;
+
+    middleware = new RateLimitMiddleware(redisService);
+    req = {
+      header: jest.fn(),
+      ip: '127.0.0.1',
+    };
+    res = {};
     next = jest.fn();
   });
 
-  it('sets TTL on first request', async () => {
+  it('sets TTL on first request with API key', async () => {
     req.header.mockReturnValue('my-api-key');
-    mockIncr.mockResolvedValue(1);
-    mockExpire.mockResolvedValue(1);
+    redisService.incr.mockResolvedValue(1);
+    redisService.expire.mockResolvedValue(undefined);
 
-    await middleware.use(
-      req as unknown as import('express').Request,
-      res as unknown as import('express').Response,
-      next,
+    await middleware.use(req, res, next);
+
+    expect(redisService.incr).toHaveBeenCalledWith('rate_limit:key:my-api-key');
+    expect(redisService.expire).toHaveBeenCalledWith(
+      'rate_limit:key:my-api-key',
+      60,
     );
-
-    expect(mockExpire).toHaveBeenCalledWith('rate_limit:my-api-key', 60);
     expect(next).toHaveBeenCalled();
   });
 
-  it('allows requests under the limit', async () => {
-    req.header.mockReturnValue('my-api-key');
-    mockIncr.mockResolvedValue(50);
+  it('sets TTL on first request without API key (using IP)', async () => {
+    req.header.mockReturnValue(undefined);
+    req.ip = '192.168.1.1';
+    redisService.incr.mockResolvedValue(1);
+    redisService.expire.mockResolvedValue(undefined);
 
-    await middleware.use(
-      req as unknown as import('express').Request,
-      res as unknown as import('express').Response,
-      next,
+    await middleware.use(req, res, next);
+
+    expect(redisService.incr).toHaveBeenCalledWith('rate_limit:ip:192.168.1.1');
+    expect(redisService.expire).toHaveBeenCalledWith(
+      'rate_limit:ip:192.168.1.1',
+      60,
     );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('allows requests under the limit for API key', async () => {
+    req.header.mockReturnValue('my-api-key');
+    redisService.incr.mockResolvedValue(50);
+
+    await middleware.use(req, res, next);
 
     expect(next).toHaveBeenCalled();
   });
 
   it('throws 429 when over the limit for API key', async () => {
     req.header.mockReturnValue('my-api-key');
-    mockIncr.mockResolvedValue(101);
+    redisService.incr.mockResolvedValue(101);
 
-    await expect(
-      middleware.use(
-        req as unknown as import('express').Request,
-        res as unknown as import('express').Response,
-        next,
-      ),
-    ).rejects.toThrow(HttpException);
+    await expect(middleware.use(req, res, next)).rejects.toThrow(HttpException);
   });
 
-  it('enforces lower limit for anonymous users', async () => {
+  it('enforces lower limit for anonymous users (by IP)', async () => {
     req.header.mockReturnValue(undefined);
-    mockIncr.mockResolvedValue(11);
+    req.ip = '1.2.3.4';
+    redisService.incr.mockResolvedValue(11);
 
-    await expect(
-      middleware.use(
-        req as unknown as import('express').Request,
-        res as unknown as import('express').Response,
-        next,
-      ),
-    ).rejects.toThrow(HttpException);
+    await expect(middleware.use(req, res, next)).rejects.toThrow(HttpException);
   });
 
   it('does not set TTL if not first request', async () => {
     req.header.mockReturnValue('my-api-key');
-    mockIncr.mockResolvedValue(2);
+    redisService.incr.mockResolvedValue(2);
 
-    await middleware.use(
-      req as unknown as import('express').Request,
-      res as unknown as import('express').Response,
-      next,
-    );
+    await middleware.use(req, res, next);
 
-    expect(mockExpire).not.toHaveBeenCalled();
+    expect(redisService.expire).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('allows request to proceed if Redis fails', async () => {
+    req.header.mockReturnValue('my-api-key');
+    redisService.incr.mockRejectedValue(new Error('Redis connection lost'));
+
+    await middleware.use(req, res, next);
+
     expect(next).toHaveBeenCalled();
   });
 });

--- a/backend/src/market-data/rate-limit.middleware.ts
+++ b/backend/src/market-data/rate-limit.middleware.ts
@@ -15,9 +15,13 @@ export class RateLimitMiddleware implements NestMiddleware {
 
   async use(req: Request, res: Response, next: NextFunction) {
     try {
-      const apiKey = req.header('x-api-key') || 'anonymous';
-      const key = `rate_limit:${apiKey}`;
-      const limit = apiKey === 'anonymous' ? 10 : 100; // 10 req/min anonymous, 100 req/min with key
+      const apiKey = req.header('x-api-key');
+      // Use API key if provided, otherwise fall back to IP address
+      // Use different prefixes to avoid key collisions and improve monitoring
+      const key = apiKey
+        ? `rate_limit:key:${apiKey}`
+        : `rate_limit:ip:${req.ip}`;
+      const limit = apiKey ? 100 : 10; // 10 req/min per IP, 100 req/min per API key
       const ttlSeconds = 60;
 
       const current = await this.redisService.incr(key);


### PR DESCRIPTION
The `RateLimitMiddleware` in the market-data module previously used a hardcoded string `'anonymous'` as the identifier for all requests lacking an `x-api-key`. This created a vulnerability where one malicious or aggressive anonymous user could exhaust the shared 10 requests-per-minute bucket, effectively performing a Denial of Service on all other anonymous users.

This PR refactors the identification logic to use the request's IP address (`req.ip`) when the API key is missing. It also introduces structured Redis keys (`rate_limit:ip:...` and `rate_limit:key:...`) to improve monitoring and prevent accidental key collisions. The tiered limits (100/min for keys, 10/min for IPs) remain in place but are now applied per-identifier.

Verification:
- New unit tests in `backend/src/market-data/__tests__/rate-limit.middleware.spec.ts` pass with 100% coverage for the new logic.
- Manual verification of the fail-open logic (allowing requests if Redis is down) was performed via unit tests.
- Linting and formatting checks were run for the affected files.

---
*PR created automatically by Jules for task [3128853203248510618](https://jules.google.com/task/3128853203248510618) started by @ArtCenter1*