### PR TITLE
🛡️ Sentinel: Mask Redis password in connection logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -36,3 +36,8 @@
 **Vulnerability:** Upstream error data from CoinGecko and Binance was being passed directly to the client via the `data` field in error responses.
 **Learning:** Third-party APIs may include sensitive metadata, internal stack traces, or quota details in their error bodies. Direct passthrough of these bodies violates the principle of "Fail Securely".
 **Prevention:** Intercept all upstream errors and map them to a standardized, safe error format that excludes the raw response body.
+
+## 2026-06-12 - Sensitive Information Leakage in Redis Connection Logs
+**Vulnerability:** The `RedisService` was logging the full `REDIS_URL` during initialization, which could contain the plaintext password if it was included in the connection string (e.g., `redis://:password@host:port`).
+**Learning:** Standard library connection strings often contain embedded credentials. Logging these strings directly violates the principle of "Exposed sensitive data in logs".
+**Prevention:** Always sanitize or mask connection strings and URLs before logging them. Use a dedicated masking function or regular expression to redact sensitive components like passwords while preserving the rest of the URL for debugging purposes.

--- a/backend/src/redis/redis.service.ts
+++ b/backend/src/redis/redis.service.ts
@@ -22,7 +22,9 @@ export class RedisService implements OnModuleInit {
     try {
       const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
 
-      this.logger.log(`Attempting to connect to Redis at ${redisUrl}`);
+      // Security: Mask password in Redis URL before logging
+      const maskedUrl = redisUrl.replace(/\/\/([^:]*):([^@]+)@/, '//$1:****@');
+      this.logger.log(`Attempting to connect to Redis at ${maskedUrl}`);
 
       this.client = new Redis(redisUrl, {
         maxRetriesPerRequest: 3,


### PR DESCRIPTION
This PR addresses a security vulnerability where the Redis connection password was being logged in plaintext during the application bootstrap.

The `RedisService` now uses a regular expression to mask the password section of the `REDIS_URL` before it is passed to the logger, while ensuring the original URL is still used for the actual connection.

Severity: MEDIUM
Vulnerability: Exposed sensitive data in logs.
Impact: Potential credential exposure to anyone with access to system logs.
Fix: Implemented password masking in `backend/src/redis/redis.service.ts`.
Verification: Created a temporary unit test that mocks the Logger and verifies that the logged string contains `****` instead of the actual password.

---
*PR created automatically by Jules for task [7862753168150251877](https://jules.google.com/task/7862753168150251877) started by @ArtCenter1*