### PR TITLE
🛡️ Sentinel: [security improvement] Sanitize proxy error responses

### DIFF
--- a/backend/src/market-data/binance-testnet-proxy.controller.ts
+++ b/backend/src/market-data/binance-testnet-proxy.controller.ts
@@ -73,8 +73,6 @@ export class BinanceTestnetProxyController {
         return {
           error: true,
           status: error.response.status,
-          // data: error.response.data, // Removed to avoid leaking upstream API details
-          message: `Binance Testnet API error: ${error.message}`,
           // Security: Do not leak raw error data from upstream API
           message:
             error.response.status === 429

--- a/backend/src/market-data/coingecko-proxy.controller.ts
+++ b/backend/src/market-data/coingecko-proxy.controller.ts
@@ -11,7 +11,6 @@ import axios from 'axios';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Request } from 'express';
 import { RedisService } from '../redis/redis.service';
-import { CircuitBreakerService } from './circuit-breaker.service';
 import {
   CircuitBreakerService,
   CircuitBreakerState,
@@ -498,8 +497,6 @@ export class CoinGeckoProxyController {
         const errorResponse: ErrorResponse = {
           error: true,
           status: error.response?.status || 500,
-          message: error.message,
-          // data: (error.response?.data as Record<string, unknown>) || null, // Removed to avoid leaking upstream API details
           message:
             error.response?.status === 429
               ? 'CoinGecko rate limit exceeded. Please try again later.'


### PR DESCRIPTION
This PR fixes build-breaking errors in the `CoinGeckoProxyController` and `BinanceTestnetProxyController` that were introduced during a previous security hardening attempt. 

Specifically:
- Removed duplicate imports of `CircuitBreakerService` in `CoinGeckoProxyController`.
- Removed duplicate `message` property keys in the `catch` blocks of both controllers, ensuring that only the sanitized, generic error message is returned to the client.
- Cleaned up commented-out code that was leaking upstream API details.

These changes ensure the backend can build successfully while maintaining the "Fail Securely" principle by preventing information leakage from third-party APIs.

Verification:
- Ran `cd backend && npx jest src/market-data/__tests__/proxy-security.spec.ts` (Passed).
- Ran `cd backend && npm run build` (Passed).

---
*PR created automatically by Jules for task [3039287838834137197](https://jules.google.com/task/3039287838834137197) started by @ArtCenter1*