### PR TITLE
🛡️ Sentinel: [security enhancement] Enable Firebase token revocation check

### DIFF
--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -3,12 +3,15 @@ import {
   CanActivate,
   ExecutionContext,
   UnauthorizedException,
+  Logger,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import * as admin from 'firebase-admin';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
+  private readonly logger = new Logger(JwtAuthGuard.name);
+
   canActivate(
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
@@ -25,7 +28,7 @@ export class JwtAuthGuard implements CanActivate {
 
     try {
       // Verify the Firebase token
-      const decodedToken = await admin.auth().verifyIdToken(token);
+      const decodedToken = await admin.auth().verifyIdToken(token, true);
 
       // Attach the user to the request object
       request.user = {
@@ -36,7 +39,7 @@ export class JwtAuthGuard implements CanActivate {
 
       return true;
     } catch (error) {
-      console.error('Error validating token:', error);
+      this.logger.error('Error validating token:', error);
       throw new UnauthorizedException('Invalid token');
     }
   }

--- a/backend/src/market-data/__tests__/binance-proxy.spec.ts
+++ b/backend/src/market-data/__tests__/binance-proxy.spec.ts
@@ -48,7 +48,7 @@ describe('BinanceTestnetProxyController', () => {
       error: true,
       status: 400,
       // data: mockErrorData, // No longer leaked
-      message: 'Binance Testnet API error: Request failed with status code 400',
+      message: 'An error occurred while fetching data from Binance Testnet.',
     });
     expect(result['data']).toBeUndefined();
   });

--- a/backend/src/middleware/firebase-auth.middleware.ts
+++ b/backend/src/middleware/firebase-auth.middleware.ts
@@ -58,7 +58,7 @@ export class FirebaseAuthMiddleware implements NestMiddleware {
     }
 
     try {
-      const decodedToken = await admin.auth().verifyIdToken(token);
+      const decodedToken = await admin.auth().verifyIdToken(token, true);
       // Attach user info to the request object
       req.user = { user_id: decodedToken.uid };
       logger.debug(`Authenticated user: ${decodedToken.uid}`);


### PR DESCRIPTION
🚨 Severity: MEDIUM (Security Enhancement)
💡 Vulnerability: Firebase ID tokens were being verified without checking if they had been revoked. This allowed revoked tokens (e.g., from password resets or manual revocation) to remain valid until their natural expiration.
🎯 Impact: Revoked sessions could potentially be used by an attacker if a token was compromised before revocation.
🔧 Fix: Enabled the `checkRevoked` parameter in `admin.auth().verifyIdToken(token, true)` across both `FirebaseAuthMiddleware` and `JwtAuthGuard`. Also updated `JwtAuthGuard` to use the standard NestJS `Logger` and fixed a pre-existing test regression in `binance-proxy.spec.ts` where the test expected insecure verbose error leakage.
✅ Verification: Verified that the backend builds and `binance-proxy.spec.ts` passes. Ran the full test suite and confirmed core functionality remains intact.

---
*PR created automatically by Jules for task [1525093535737087875](https://jules.google.com/task/1525093535737087875) started by @ArtCenter1*